### PR TITLE
Remove commented code due to parse error

### DIFF
--- a/resources/js/input.js
+++ b/resources/js/input.js
@@ -16,39 +16,5 @@ $(function () {
                 counter.removeClass('text-danger');
             }
         });
-
-        /*$(this).textcomplete([
-         {
-         tags: ['{{ entry.last_name }}', '{{ forms_display($slug) }}'],
-         match: /{{2}\s[a-z_.]+(?!}})$/,
-         search: function (term, callback) {
-         callback($.map(this.tags, function (tag) {
-         return tag.indexOf(term) === 0 ? tag : null;
-         }));
-         },
-         index: 0,
-         replace: function (tag) {
-         return tag;
-         }
-         },
-         {
-         tags: [
-         '{input.subject}',
-         '{input.email}',
-         '{input.phone}',
-         '{input.name}'
-         ],
-         match: /{{1}[a-z_.]+(?!}})$/,
-         search: function (term, callback) {
-         callback($.map(this.tags, function (tag) {
-         return tag.indexOf(term) === 0 ? tag : null;
-         }));
-         },
-         index: 0,
-         replace: function (tag) {
-         return tag;
-         }
-         }
-         ]);*/
     });
 });


### PR DESCRIPTION
When you leave this commented code in there and your theme is setup to parse JS scripts it crashes due to the "$slug" in the commented code.  Suggest removing this leftover stuff.