### PR TITLE
Broken under new versions of jquery

### DIFF
--- a/resources/js/input.js
+++ b/resources/js/input.js
@@ -1,4 +1,4 @@
-$(document).on('ajaxComplete ready', function () {
+$(document).ready(function () {
 
     // Initialize text suggestions
     $('textarea[data-provides="anomaly.field_type.textarea"]:not([data-initialized])').each(function () {
@@ -18,39 +18,5 @@ $(document).on('ajaxComplete ready', function () {
                 counter.removeClass('text-danger');
             }
         });
-
-        /*$(this).textcomplete([
-         {
-         tags: ['{{ entry.last_name }}', '{{ forms_display($slug) }}'],
-         match: /{{2}\s[a-z_.]+(?!}})$/,
-         search: function (term, callback) {
-         callback($.map(this.tags, function (tag) {
-         return tag.indexOf(term) === 0 ? tag : null;
-         }));
-         },
-         index: 0,
-         replace: function (tag) {
-         return tag;
-         }
-         },
-         {
-         tags: [
-         '{input.subject}',
-         '{input.email}',
-         '{input.phone}',
-         '{input.name}'
-         ],
-         match: /{{1}[a-z_.]+(?!}})$/,
-         search: function (term, callback) {
-         callback($.map(this.tags, function (tag) {
-         return tag.indexOf(term) === 0 ? tag : null;
-         }));
-         },
-         index: 0,
-         replace: function (tag) {
-         return tag;
-         }
-         }
-         ]);*/
     });
 });


### PR DESCRIPTION
document.on(ready) was deprecated in jquery 1.8 and removed in jquery 3.  It's broken on all modern versions of jquery.  The commented code causes errors and needs to be removed.